### PR TITLE
feat: Added base SingleInputs class

### DIFF
--- a/src/yieldplotlib/core/single_inputs.py
+++ b/src/yieldplotlib/core/single_inputs.py
@@ -15,7 +15,7 @@ class SingleInput(dict):
     def apply(self, key, func):
         """Apply a function to all values of a given key."""
         try:
-            self.update(key=func(self.get(key)))
+            self[key] = func(self.get(key))
         except TypeError:
             raise TypeError(f'Could not apply function to {key}')
 

--- a/src/yieldplotlib/core/single_inputs.py
+++ b/src/yieldplotlib/core/single_inputs.py
@@ -4,6 +4,7 @@
 various types of yield inputs. It inherits from dict for direct access to
 built-in dictionary functions such as get(), update(), etc.
 """
+from yieldplotlib.logger import logger
 
 
 class SingleInput(dict):
@@ -40,4 +41,4 @@ class SingleInput(dict):
                 raise AttributeError(f'{key} does not have a value of type astropy.units.Quantity')
 
         finally:
-            print('All unit checks passed.')
+            logger.info('All unit checks passed.')

--- a/src/yieldplotlib/core/single_inputs.py
+++ b/src/yieldplotlib/core/single_inputs.py
@@ -22,17 +22,22 @@ class SingleInput(dict):
     def check_units(self, key, desired_unit):
         """Checks that all values of key have the appropriate desired unit."""
         try:
-            for value in self.get(key):
-                if value.unit != desired_unit:
-                    raise AssertionError(f"Value {value} for {key} does not have desired "
+            iterator = iter(self.get(key))
+            try:
+                for value in iterator:
+                    if value.unit != desired_unit:
+                        raise AssertionError(f"Value {value} for {key} does not have desired "
+                                             f"unit {desired_unit}")
+            except AttributeError:
+                raise AttributeError(f'{key} does not have a value of type astropy.units.Quantity')
+
+        except TypeError:
+            try:
+                if self.get(key).unit != desired_unit:
+                    raise AssertionError(f"Value {self.get(key)} for {key} does not have desired "
                                          f"unit {desired_unit}")
-        except AttributeError:
-            raise AttributeError(f'{key} does not have a value of type astropy.units.Quantity')
+            except AttributeError:
+                raise AttributeError(f'{key} does not have a value of type astropy.units.Quantity')
 
-
-
-
-
-
-
-
+        finally:
+            print('All unit checks passed.')

--- a/src/yieldplotlib/core/single_inputs.py
+++ b/src/yieldplotlib/core/single_inputs.py
@@ -1,0 +1,38 @@
+"""The base `SingleInput` class.
+
+`SingleInput` is a class designed to facilitate the reading, setting, and manipulation of
+various types of yield inputs. It inherits from dict for direct access to
+built-in dictionary functions such as get(), update(), etc.
+"""
+
+
+class SingleInput(dict):
+    """Base class for all Inputs."""
+
+    def __init__(self, *args, **kwargs):
+        super(SingleInput, self).__init__(*args, **kwargs)
+
+    def apply(self, key, func):
+        """Apply a function to all values of a given key."""
+        try:
+            self.update(key=func(self.get(key)))
+        except TypeError:
+            raise TypeError(f'Could not apply function to {key}')
+
+    def check_units(self, key, desired_unit):
+        """Checks that all values of key have the appropriate desired unit."""
+        try:
+            for value in self.get(key):
+                if value.unit != desired_unit:
+                    raise AssertionError(f"Value {value} for {key} does not have desired "
+                                         f"unit {desired_unit}")
+        except AttributeError:
+            raise AttributeError(f'{key} does not have a value of type astropy.units.Quantity')
+
+
+
+
+
+
+
+


### PR DESCRIPTION
First pass at a base class for single inputs (as opposed to ensemble inputs). I decided to inherit from dict and have been trying to come up with reasons why that could be a bad idea and would appreciate input on that. 

Also added a couple of functions that I thought would be shared amongst all inputs like unit checking and applying a function to all values for a key (i.e. could be useful when converting between different lambda/D units). 

I don't have a ton of experience with writing base classes as generic as this so any and all feedback is welcome.
