### PR TITLE
Bugfix/exosims units

### DIFF
--- a/src/yieldplotlib/core/file_nodes.py
+++ b/src/yieldplotlib/core/file_nodes.py
@@ -173,12 +173,12 @@ class FitsFile(FileNode):
         self.file_name = posixpath.basename(file_path)
 
     def load(self):
-        """Load the pickle file into memory."""
+        """Load the fits file."""
         self.fits_file = pyfits.open(self.file_path)
 
     def get(self, key: str):
         """Return the data associated with the key."""
         if key == "data":
-            return pyfits.getdata(self.fits_file)
+            return pyfits.getdata(self.file_path)
         else:
-            return pyfits.getheader(self.fits_file).get(key, None)
+            return pyfits.getheader(self.file_path).get(key, None)

--- a/src/yieldplotlib/generate_key_map.py
+++ b/src/yieldplotlib/generate_key_map.py
@@ -41,6 +41,7 @@ def parse_csv(input_csv):
             ayo_name = row.get("AYO name", "").strip()
             ayo_file = row.get("AYO file", "").strip()
             ayo_class = row.get("AYO Class", "").strip()
+            exo_unit = row.get("EXOSIMS unit", "").strip()
             comment = row.get("Comment", "").strip()
 
             # New columns for transformation
@@ -83,6 +84,7 @@ def parse_csv(input_csv):
                     "class": exo_class,
                     "file": exo_file,
                     "name": exo_name,
+                    "unit": exo_unit,
                     "transform": {
                         "type": exo_transform_type if exo_transform_type else "none",
                         "value": exo_transform_value if exo_transform_value else None,
@@ -136,6 +138,7 @@ def parse_csv(input_csv):
             map_entry[exo_class] = {
                 "file": exo_entry["file"],
                 "name": exo_entry["name"],
+                "unit": exo_entry["unit"],
                 "transform": {
                     "type": exo_entry["transform"]["type"],
                     "value": exo_entry["transform"]["value"],
@@ -210,6 +213,8 @@ def write_key_map(key_map, output_py):
                     f.write(f'        "{lib_class}": {{\n')
                     f.write(f'            "file": "{lib_entry["file"]}",\n')
                     f.write(f'            "name": "{lib_entry["name"]}",\n')
+                    if lib_class.startswith("EXOSIMS"):
+                        f.write(f'            "unit": "{lib_entry["unit"]}",\n')
                     # Handle transformation details
                     transform_type = lib_entry["transform"]["type"]
                     transform_value = lib_entry["transform"]["value"]

--- a/src/yieldplotlib/load/exosims/exosims_input_file.py
+++ b/src/yieldplotlib/load/exosims/exosims_input_file.py
@@ -66,7 +66,7 @@ class EXOSIMSInputFile(JSONFile):
                 return values
 
         else:
-            if key in INSTRUMENT_KEYS or MODE_KEYS:
+            if key in INSTRUMENT_KEYS or key in MODE_KEYS:
                 if key.startswith("sc"):  # indicates spectroscopy parameter.
                     for k in values.copy().keys():
                         if "spectro" not in k or k not in used_instruments:

--- a/src/yieldplotlib/load/exosims/exosims_input_file.py
+++ b/src/yieldplotlib/load/exosims/exosims_input_file.py
@@ -4,8 +4,10 @@ from pathlib import Path
 
 from astropy import units as u
 
-from yieldplotlib.core.file_nodes import JSONFile
+from yieldplotlib.logger import logger
+from yieldplotlib.core.file_nodes import JSONFile, FitsFile
 from yieldplotlib.key_map import KEY_MAP
+
 
 # Define which nested keys correspond to the modes, systems, and
 # instruments for parsing.
@@ -24,7 +26,7 @@ INSTRUMENT_KEYS += ["sc_" + k for k in INSTRUMENT_KEYS]
 MODE_KEYS = ["obs_lam", "snr"]
 MODE_KEYS += ["sc_" + k for k in MODE_KEYS]
 
-SYSTEM_KEYS = ["coron_lam", "iwa", "owa", "bw", "optics"]
+SYSTEM_KEYS = ["coron_lam", "iwa", "owa", "bw", "optics", "core_thruput"]
 
 
 class EXOSIMSInputFile(JSONFile):
@@ -81,8 +83,14 @@ class EXOSIMSInputFile(JSONFile):
                     if k not in used_systems:
                         del values[k]
 
-        if unit:
-            for k, v in values.items():
+        for k, v in values.items():
+            if unit:
                 values[k] = v * unit
+            if v.endswith(".fits"):
+                try:
+                    values[k] = FitsFile(Path(v))
+                except FileNotFoundError:
+                    logger.info(f"File path {v} does not exist on the local machine. "
+                                f"Could not create FitsFile object")
 
         return values

--- a/src/yieldplotlib/load/exosims/exosims_input_file.py
+++ b/src/yieldplotlib/load/exosims/exosims_input_file.py
@@ -4,10 +4,9 @@ from pathlib import Path
 
 from astropy import units as u
 
-from yieldplotlib.logger import logger
-from yieldplotlib.core.file_nodes import JSONFile, FitsFile
+from yieldplotlib.core.file_nodes import FitsFile, JSONFile
 from yieldplotlib.key_map import KEY_MAP
-
+from yieldplotlib.logger import logger
 
 # Define which nested keys correspond to the modes, systems, and
 # instruments for parsing.
@@ -90,7 +89,9 @@ class EXOSIMSInputFile(JSONFile):
                 try:
                     values[k] = FitsFile(Path(v))
                 except FileNotFoundError:
-                    logger.info(f"File path {v} does not exist on the local machine. "
-                                f"Could not create FitsFile object")
+                    logger.info(
+                        f"File path {v} does not exist on the local machine. "
+                        f"Could not create FitsFile object"
+                    )
 
         return values

--- a/src/yieldplotlib/load/exosims/exosims_input_file.py
+++ b/src/yieldplotlib/load/exosims/exosims_input_file.py
@@ -1,9 +1,11 @@
 """Node for handling input json files."""
 
 from pathlib import Path
+
 from astropy import units as u
-from yieldplotlib.key_map import KEY_MAP
+
 from yieldplotlib.core.file_nodes import JSONFile
+from yieldplotlib.key_map import KEY_MAP
 
 # Define which nested keys correspond to the modes, systems, and
 # instruments for parsing.

--- a/src/yieldplotlib/load/exosims/exosims_input_file.py
+++ b/src/yieldplotlib/load/exosims/exosims_input_file.py
@@ -36,6 +36,7 @@ class EXOSIMSInputFile(JSONFile):
         self.is_input = True
 
     def get_unit(self, key: str):
+        """Get the associated unit for a given key."""
         entry = KEY_MAP[key]
         unit = entry["EXOSIMSInputFile"]["unit"]
 


### PR DESCRIPTION
Fixes #36. 

Add an EXOSIMS unit column that is read by generate_key_map.py and written to the key_map.py file. The units are then used in the EXOSIMSInputFile get function to yield astropy.units Quantities instead of floats or ints.    