### PR TITLE
Core throughput consistency 

### DIFF
--- a/src/yieldplotlib/load/exosims/exosims_input_file.py
+++ b/src/yieldplotlib/load/exosims/exosims_input_file.py
@@ -95,9 +95,6 @@ TL_PARAMS = [
 SPECIAL_KEYS = {
     "blind_comp_det": "_get_comp_per_intTime",
     "blind_comp_spec": "_get_comp_per_intTime",
-}
-
-OVERRIDE_KEYS = {
     "core_thruput": "_get_core_thruput",
 }
 
@@ -291,8 +288,6 @@ class EXOSIMSInputFile(JSONFile):
         """
         if key in SPECIAL_KEYS:
             return getattr(self, SPECIAL_KEYS[key])(key, **kwargs)
-        if key in OVERRIDE_KEYS:
-            return getattr(self, OVERRIDE_KEYS[key])()
         in_TL = key in TL_PARAMS
         if in_TL:
             # Simple case, just return the value from the TargetList object
@@ -531,7 +526,7 @@ class EXOSIMSInputFile(JSONFile):
 
         return result
 
-    def _get_core_thruput(self):
+    def _get_core_thruput(self, *args, **kwargs):
         """Get the core thruput data."""
         # Get both wavelength and core throughput
         thruput_fits = self.data["starlightSuppressionSystems"][0]["core_thruput"]

--- a/src/yieldplotlib/load/exosims/exosims_input_file.py
+++ b/src/yieldplotlib/load/exosims/exosims_input_file.py
@@ -536,9 +536,11 @@ class EXOSIMSInputFile(JSONFile):
         thruput_fits = self.data["starlightSuppressionSystems"][0][
             "core_thruput"]
         if os.path.exists(thruput_fits):
+            # Load fully qualified file path.
             thruput_data = pyfits.getdata(Path(thruput_fits))
         else:
             try:
+                # See if file is in the same directory as the input JSON.
                 thruput_data = pyfits.getdata(Path(os.path.dirname(self.file_path), thruput_fits))
             except FileNotFoundError:
                 logger.warning(

--- a/src/yieldplotlib/load/exosims/exosims_input_file.py
+++ b/src/yieldplotlib/load/exosims/exosims_input_file.py
@@ -1,12 +1,13 @@
 """Node for handling input json files."""
 
 import copy
-from pathlib import Path
 import os
+from pathlib import Path
+
+import astropy.io.fits as pyfits
 import numpy as np
 import pandas as pd
 from astropy import units as u
-import astropy.io.fits as pyfits
 from EXOSIMS.Prototypes.OpticalSystem import OpticalSystem
 from EXOSIMS.util.get_module import get_module_from_specs
 
@@ -533,22 +534,23 @@ class EXOSIMSInputFile(JSONFile):
     def _get_core_thruput(self):
         """Get the core thruput data."""
         # Get both wavelength and core throughput
-        thruput_fits = self.data["starlightSuppressionSystems"][0][
-            "core_thruput"]
+        thruput_fits = self.data["starlightSuppressionSystems"][0]["core_thruput"]
         if os.path.exists(thruput_fits):
             # Load fully qualified file path.
             thruput_data = pyfits.getdata(Path(thruput_fits))
         else:
             try:
                 # See if file is in the same directory as the input JSON.
-                thruput_data = pyfits.getdata(Path(os.path.dirname(self.file_path), thruput_fits))
+                thruput_data = pyfits.getdata(
+                    Path(os.path.dirname(self.file_path), thruput_fits)
+                )
             except FileNotFoundError:
                 logger.warning(
                     "No core throuphput file found for EXOSIMS, check file paths in"
-                    " the input JSON are correct. ")
+                    " the input JSON are correct. "
+                )
                 return None
         sep = thruput_data[:, 0]
         thruput = thruput_data[:, 1]
         df = pd.DataFrame({"sep": sep, "thruput": thruput})
         return df
-

--- a/src/yieldplotlib/plots/yip_plots.py
+++ b/src/yieldplotlib/plots/yip_plots.py
@@ -127,14 +127,8 @@ def plot_core_throughtput(
         ax.plot(separations, core_thruput_from_yip, label="yippy")
 
     for i, run in enumerate(runs):
-        fits = run.get("core_thruput")
-        if isinstance(fits, dict):
-            for name in fits:
-                thruput_data = fits[name].get("data")
-                ax.plot(thruput_data[:, 0], thruput_data[:, 1], label=run_labels[i])
-        else:
-            thruput_data = fits.get("data")
-            ax.plot(thruput_data[:, 0], thruput_data[:, 1], label=f"{run_labels[i]}")
+        data = run.get("core_thruput")
+        ax.plot(data["sep"], data["thruput"], label=f"{run_labels[i]}")
 
     ax.set(**ax_kwargs)
     plt.xlabel("Separation ($\\lambda/D$)")


### PR DESCRIPTION
Add `_get_core_thruput` function to `exosims_input_file.py` to have `ayo.get('core_thruput')` and `exosims.get('core_thruput')` return the same pandas data frame.

Would appreciate feedback whether this is the best way to handle it since the loaders are quite complex  